### PR TITLE
fix: remove redundant code from find_max_connects_in_matrix_of_0s_and_1s.go

### DIFF
--- a/chapter02-recursion-and-backtracking/find_max_connects_in_matrix_of_0s_and_1s.go
+++ b/chapter02-recursion-and-backtracking/find_max_connects_in_matrix_of_0s_and_1s.go
@@ -73,11 +73,5 @@ func main() {
 		}
 	}
 
-	maxConnects := 0
-	for r := 0; r < M; r++ {
-		for c := 0; c < N; c++ {
-			maxConnects = max(maxConnects, findConnects(matrix, M, N, r, c))
-		}
-	}
 	fmt.Println(findMaxConnects(matrix, M, N))
 }


### PR DESCRIPTION
The example has redundant code. Also, Prints wrong result as all the 1's is rewritten to 0 from the removed loop.